### PR TITLE
Fix field variable in NTT constants generation

### DIFF
--- a/ntt.py
+++ b/ntt.py
@@ -93,7 +93,7 @@ def intt(f_ntt):
     elif (n == 2):
         f = [0] * n
         f[0] = (i2 * (f_ntt[0] + f_ntt[1])) % q
-        f[1] = (i2 * inv_mod_q[1479] * (f_ntt[0] - f_ntt[1])) % q
+        f[1] = (i2 * inv_mod_q[sqr1] * (f_ntt[0] - f_ntt[1])) % q
     return f
 
 

--- a/scripts/generate_constants.sage
+++ b/scripts/generate_constants.sage
@@ -19,7 +19,7 @@ phi2048_roots = sum([[sqrt(elt), - sqrt(elt)] for elt in phi1024_roots], [])
 	for q = 12 * 1024 + 1 and n = 4, 8, 16, ..., 1024."""
 q = 12 * 1024 + 1
 Zq = Integers(q)
-phi4_roots_Zq = [sqrt(R(- 1)), - sqrt(R(- 1))]
+phi4_roots_Zq = [sqrt(Zq(- 1)), - sqrt(Zq(- 1))]
 phi8_roots_Zq = sum([[sqrt(elt), - sqrt(elt)] for elt in phi4_roots_Zq], [])
 phi16_roots_Zq = sum([[sqrt(elt), - sqrt(elt)] for elt in phi8_roots_Zq], [])
 phi32_roots_Zq = sum([[sqrt(elt), - sqrt(elt)] for elt in phi16_roots_Zq], [])


### PR DESCRIPTION
Hi,

I noticed a small typo in the NTT constant generation script, that prevents from directly reproducing this step.